### PR TITLE
Add download and clean features

### DIFF
--- a/normapy/models.py
+++ b/normapy/models.py
@@ -26,3 +26,13 @@ class Producto(models.Model):
 
     def __str__(self):
         return f"{self.nombre} ({self.sku})"
+
+
+class HistorialImportacion(models.Model):
+    nombre_archivo = models.CharField(max_length=255)
+    fecha_importacion = models.DateTimeField(auto_now_add=True)
+    productos_importados = models.IntegerField()
+    errores = models.TextField(null=True, blank=True)
+
+    def __str__(self):
+        return f"{self.nombre_archivo} ({self.fecha_importacion.date()})"

--- a/normapy/templates/normapy/preview.html
+++ b/normapy/templates/normapy/preview.html
@@ -16,6 +16,8 @@
 </head>
 <body>
     <h1>Vista previa de importación – NormaPy</h1>
+    <img src="/static/logo.png" alt="NormaPy Logo" style="height:50px;">
+    <p>NormaPy es una herramienta para la normalización de productos antes de importarlos a un sistema de inventario.</p>
 
     <p>
         <strong>Subir archivo CSV o Excel</strong>
@@ -23,6 +25,7 @@
             {% csrf_token %}
             {{ form.as_p }}
             <button type="submit">Subir archivo</button>
+            <button type="submit" name="limpiar" value="1">Limpiar datos</button>
         </form>
     </p>
 
@@ -80,6 +83,15 @@
             {{ form.as_p }}
             <button type="submit" name="confirmar" value="1">Confirmar importación</button>
         </form>
+        {% if estadisticas %}
+        <h2>Resumen de datos importados</h2>
+        <ul>
+            <li>Total de productos: {{ estadisticas.total_productos }}</li>
+            <li>Precio promedio: {{ estadisticas.precio_promedio }}</li>
+            <li>Stock total: {{ estadisticas.stock_total }}</li>
+            <li>SKUs generados: {{ estadisticas.skus_generados }}</li>
+        </ul>
+        {% endif %}
     {% else %}
         <p>No hay datos para mostrar. Por favor sube un archivo.</p>
     {% endif %}

--- a/normapy/templates/normapy/productos.html
+++ b/normapy/templates/normapy/productos.html
@@ -11,6 +11,8 @@
 </head>
 <body>
     <h1>Productos importados</h1>
+    <img src="/static/logo.png" alt="NormaPy Logo" style="height:50px;">
+    <p>NormaPy es una herramienta para la normalización de productos antes de importarlos a un sistema de inventario.</p>
     <form action="{% url 'exportar_productos' %}" method="get" style="margin-bottom: 20px;">
         <label for="formato">Exportar como:</label>
         <select name="formato" id="formato">
@@ -21,6 +23,14 @@
     </form>
     <form action="{% url 'exportar_json' %}" method="get" style="margin-bottom: 20px; display:inline-block;">
         <button type="submit">Exportar a JSON</button>
+    </form>
+    <form action="{% url 'descargar_normalizado' %}" method="get" style="margin-bottom: 20px; display:inline-block;">
+        <label for="formato2">Descargar archivo normalizado:</label>
+        <select name="formato" id="formato2">
+            <option value="csv">CSV</option>
+            <option value="json">JSON</option>
+        </select>
+        <button type="submit">📥 Descargar archivo normalizado</button>
     </form>
     <table>
         <thead>

--- a/normapy/urls.py
+++ b/normapy/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     path('productos/', views.listar_productos, name='listar_productos'),
     path('productos/exportar/', views.exportar_productos, name='exportar_productos'),
     path('productos/exportar_json/', views.exportar_json, name='exportar_json'),
+    path('productos/descargar/', views.descargar_normalizado, name='descargar_normalizado'),
     path('importaciones/', views.historial_importaciones, name='historial_importaciones'),
     path('importaciones/<int:importacion_id>/productos/', views.productos_por_importacion, name='productos_por_importacion'),
     path('dashboard/', views.dashboard, name='dashboard'),

--- a/normapy/utils/limpieza.py
+++ b/normapy/utils/limpieza.py
@@ -1,0 +1,17 @@
+import pandas as pd
+from unidecode import unidecode
+
+
+def limpieza_basica(df: pd.DataFrame) -> pd.DataFrame:
+    """Aplica una limpieza básica de valores para vista previa."""
+
+    def _clean(value):
+        if isinstance(value, str):
+            val = unidecode(value).lower().strip()
+            val = " ".join(val.split())
+            return val if val else "Sin dato"
+        if pd.isna(value):
+            return "Sin dato"
+        return value
+
+    return df.applymap(_clean)


### PR DESCRIPTION
## Summary
- add quick cleaning utilities and show import stats
- store import history
- export normalized data as CSV or JSON
- add branding elements in templates

## Testing
- `python manage.py test normapy.tests` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687eb447476c8322a1e836f3a87e0edc