### PR TITLE
Add confirmation step for imports

### DIFF
--- a/normapy/templates/normapy/preview.html
+++ b/normapy/templates/normapy/preview.html
@@ -100,7 +100,8 @@
     {% if preview %}
         <form method="POST">
             {% csrf_token %}
-            <button type="submit" name="confirmar" value="1">Confirmar importación</button>
+            <input type="hidden" name="confirmar" value="1" />
+            <button type="submit">Confirmar importación</button>
             <button type="submit" name="limpiar" value="1" class="clean-data-button">Limpiar datos</button>
         </form>
     {% endif %}

--- a/normapy/tests/test_import_flow.py
+++ b/normapy/tests/test_import_flow.py
@@ -1,0 +1,25 @@
+from django.test import TestCase
+from django.urls import reverse
+from io import BytesIO
+from normapy.models import Producto, Importacion
+
+class ImportFlowTests(TestCase):
+    def test_preview_then_confirm(self):
+        csv_content = (
+            "sku,nombre,precio,marca,stock\n"
+            "A1,Producto1,10.5,M1,5\n"
+            "A2,Producto2,20.0,M2,3\n"
+        )
+        file = BytesIO(csv_content.encode("utf-8"))
+        file.name = "test.csv"
+        # Preview step
+        response = self.client.post(reverse('importar_archivo'), {'archivo': file})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('preview', response.context)
+        self.assertEqual(Producto.objects.count(), 0)
+        self.assertEqual(Importacion.objects.count(), 0)
+        # Confirm step using same session
+        response = self.client.post(reverse('importar_archivo'), {'confirmar': '1'}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Producto.objects.count(), 2)
+        self.assertEqual(Importacion.objects.count(), 1)


### PR DESCRIPTION
## Summary
- delay saving imported data until user confirms
- keep parsed DataFrame in session during preview
- add hidden confirmation field in preview template
- test preview/confirm workflow

## Testing
- `python manage.py test normapy.tests` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django pandas openpyxl` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687f7c8149088322b0d9d921f867b9c7