### PR TITLE
Update historial template and test view

### DIFF
--- a/normapy/templates/normapy/historial.html
+++ b/normapy/templates/normapy/historial.html
@@ -33,9 +33,9 @@
         <tbody>
             {% for imp in historial %}
             <tr>
-                <td>{{ imp.archivo_nombre }}</td>
-                <td>{{ imp.fecha|date:"Y-m-d H:i" }}</td>
-                <td>{{ imp.total_productos }}</td>
+                <td>{{ imp.nombre_original }}</td>
+                <td>{{ imp.fecha_subida|date:"Y-m-d H:i" }}</td>
+                <td>{{ imp.cantidad_productos }}</td>
             </tr>
             {% empty %}
             <tr><td colspan="3">No hay importaciones registradas.</td></tr>

--- a/normapy/tests/test_historial.py
+++ b/normapy/tests/test_historial.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.core.files.uploadedfile import SimpleUploadedFile
+from normapy.models import Importacion
+
+class HistorialViewTests(TestCase):
+    def test_historial_muestra_importacion(self):
+        Importacion.objects.create(
+            archivo=SimpleUploadedFile('test.csv', b'data'),
+            nombre_original='test.csv',
+            cantidad_productos=1,
+            columnas_detectadas='sku',
+            se_generaron_skus=False,
+        )
+        response = self.client.get(reverse('historial_importaciones'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'test.csv')


### PR DESCRIPTION
## Summary
- reference new Importacion fields in historial template
- add a regression test for historial view to ensure Importacion items are displayed

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687f7c817abc83228563a9d81b82ab9c