### PR TITLE
Simplify dashboard template and add rendering test

### DIFF
--- a/normapy/templates/normapy/dashboard.html
+++ b/normapy/templates/normapy/dashboard.html
@@ -20,38 +20,13 @@
         <a href="{% url 'historial_importaciones' %}" class="import-button" style="background-color:#ffc107; color:#333;">Historial</a>
         <a href="{% url 'dashboard' %}" class="import-button" style="background-color:#6f42c1;">Dashboard</a>
     </nav>
-<h1>Dashboard de Importaciones</h1>
-<ul>
-    <li><strong>Total de productos importados:</strong> {{ total_productos }}</li>
-    <li><strong>Total de importaciones:</strong> {{ total_importaciones }}</li>
-    <li><strong>Usuario con más importaciones:</strong> {{ usuario_top.usuario__username }} ({{ usuario_top.total }})</li>
-    <li><strong>Último archivo subido:</strong> {{ ultimo_archivo.archivo_nombre }} ({{ ultimo_archivo.fecha|date:"Y-m-d H:i" }})</li>
-</ul>
-
-<h2>Productos por marca</h2>
-<table border="1" cellpadding="6">
-    <tr>
-        <th>Marca</th>
-        <th>Total</th>
-    </tr>
-    {% for marca in productos_por_marca %}
-    <tr>
-        <td>{{ marca.marca }}</td>
-        <td>{{ marca.total }}</td>
-    </tr>
-    {% endfor %}
-</table>
-
-<h2>Importaciones por mes</h2>
-<table border="1" cellpadding="6">
-    <tr>
-        <th>Mes</th>
-        <th>Total importaciones</th>
-    </tr>
-    {% for mes in importaciones_por_mes %}
-    <tr>
-        <td>{{ mes.mes }}</td>
-        <td>{{ mes.total }}</td>
-    </tr>
-    {% endfor %}
-</table> 
+    <h1>Dashboard de Importaciones</h1>
+    <ul>
+        <li><strong>Total de productos:</strong> {{ productos }}</li>
+        <li><strong>Total de importaciones:</strong> {{ total_importaciones }}</li>
+        <li><strong>Total de stock:</strong> {{ total_stock }}</li>
+        <li><strong>Precio promedio:</strong> {{ precio_promedio }}</li>
+        <li><strong>SKUs generados automáticamente:</strong> {{ skus_generados }}</li>
+    </ul>
+</body>
+</html>

--- a/normapy/tests/test_dashboard.py
+++ b/normapy/tests/test_dashboard.py
@@ -1,0 +1,8 @@
+from django.test import TestCase
+from django.urls import reverse
+
+class DashboardViewTest(TestCase):
+    def test_dashboard_renders(self):
+        response = self.client.get(reverse('dashboard'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'normapy/dashboard.html')


### PR DESCRIPTION
## Summary
- simplify dashboard template to avoid missing context variables
- add regression test for dashboard view

## Testing
- `python manage.py test --verbosity 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687f7c82db988322a7ab036f5a1c8ceb