### PR TITLE
Add importation product view and link

### DIFF
--- a/normapy/templates/normapy/productos_por_importacion.html
+++ b/normapy/templates/normapy/productos_por_importacion.html
@@ -3,7 +3,7 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
-    <title>Historial de Importaciones</title>
+    <title>Productos por Importación</title>
     <link rel="stylesheet" href="{% static 'branding.css' %}">
     <style>
         table { border-collapse: collapse; width: 100%; margin-top: 20px; }
@@ -15,7 +15,7 @@
     <header>
         <img src="{% static 'normapy/logo.png' %}" alt="Logo NormaPy"> NormaPy
     </header>
-    <h1>Historial de Importaciones</h1>
+    <h1>Productos de la importación {{ importacion_id }}</h1>
     <nav style="text-align:center; margin-bottom:20px;">
         <a href="{% url 'importar_archivo' %}" class="import-button">Importar productos</a>
         <a href="{% url 'listar_productos' %}" class="import-button" style="background-color:#17a2b8;">Ver productos</a>
@@ -25,26 +25,28 @@
     <table>
         <thead>
             <tr>
-                <th>Archivo</th>
-                <th>Fecha</th>
-                <th>Total productos</th>
-                <th>Acciones</th>
+                <th>SKU</th>
+                <th>Nombre</th>
+                <th>Precio</th>
+                <th>Marca</th>
+                <th>Stock</th>
             </tr>
         </thead>
         <tbody>
-            {% for imp in historial %}
-            <tr>
-                <td>{{ imp.archivo_nombre }}</td>
-                <td>{{ imp.fecha|date:"Y-m-d H:i" }}</td>
-                <td>{{ imp.total_productos }}</td>
-                <td>
-                    <a href="{% url 'productos_por_importacion' imp.id %}">Ver productos</a>
-                </td>
-            </tr>
-            {% empty %}
-            <tr><td colspan="3">No hay importaciones registradas.</td></tr>
-            {% endfor %}
+            {% if productos %}
+                {% for producto in productos %}
+                <tr>
+                    <td>{{ producto.sku }}</td>
+                    <td>{{ producto.nombre }}</td>
+                    <td>{{ producto.precio }}</td>
+                    <td>{{ producto.marca }}</td>
+                    <td>{{ producto.stock }}</td>
+                </tr>
+                {% endfor %}
+            {% else %}
+                <tr><td colspan="5">No hay productos para esta importación.</td></tr>
+            {% endif %}
         </tbody>
     </table>
 </body>
-</html> 
+</html>

--- a/normapy/tests/test_views.py
+++ b/normapy/tests/test_views.py
@@ -1,0 +1,31 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.core.files.uploadedfile import SimpleUploadedFile
+from normapy.models import Importacion, Producto
+
+
+class ProductosPorImportacionTests(TestCase):
+    def setUp(self):
+        upload_file = SimpleUploadedFile('test.csv', b'dummy', content_type='text/csv')
+        self.importacion = Importacion.objects.create(
+            archivo=upload_file,
+            nombre_original='test.csv',
+            cantidad_productos=1,
+            columnas_detectadas='sku,nombre',
+            se_generaron_skus=False
+        )
+        Producto.objects.create(
+            importacion=self.importacion,
+            sku='SKU1',
+            nombre='Prod1',
+            precio=1.0,
+            stock=1,
+            marca='Brand'
+        )
+
+    def test_template_renders(self):
+        url = reverse('productos_por_importacion', args=[self.importacion.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'normapy/productos_por_importacion.html')
+        self.assertContains(response, 'Prod1')

--- a/normapy/urls.py
+++ b/normapy/urls.py
@@ -6,6 +6,9 @@ from django.conf.urls.static import static
 urlpatterns = [
     path('', views.importar_archivo, name='importar_archivo'),  # Página principal
     path('historial/', views.historial_importaciones, name='historial_importaciones'),
+    path('historial/<int:importacion_id>/productos/',
+         views.productos_por_importacion,
+         name='productos_por_importacion'),
     path('productos/', views.listar_productos, name='listar_productos'),
     path('dashboard/', views.dashboard, name='dashboard'),
     path('exportar_productos/', views.exportar_productos, name='exportar_productos'),


### PR DESCRIPTION
## Summary
- show products from a specific `Importacion`
- link the view from the history page
- cover the new view with a test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas and django)*

------
https://chatgpt.com/codex/tasks/task_e_687f7c8303bc8322be14f65ebb667ed0