### PR TITLE
Add requirements file and update install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ El sistema detecta automáticamente los nombres de columna gracias al archivo `s
    cd NormaPy
    ```
 
-2. Instala las dependencias:
+2. Instala las dependencias definidas en `requirements.txt`:
    ```
    pip install -r requirements.txt
    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Django>=5.2
+pandas>=1.3
+openpyxl>=3.1
+unidecode>=1.3
+rapidfuzz>=3.0
+pytest>=7.0
+pytest-django>=4.5


### PR DESCRIPTION
## Summary
- add `requirements.txt` with main dependencies
- document installing from this file in README

## Testing
- `python manage.py test normapy.tests` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687f7c84fc588322b2f9f05e23209e8c