### PR TITLE
Remove redundant mapear_columnas from views

### DIFF
--- a/normapy/views.py
+++ b/normapy/views.py
@@ -91,22 +91,6 @@ def validar_mapeo(mapeo, df_columns):
     print("🗺️ Mapeo generado:", mapeo)
     return True
 
-def mapear_columnas(df, sinonimos_global, sinonimos_proveedor=None):
-    """Mapea las columnas del archivo CSV/Excel a las columnas internas del sistema."""
-    mapeo = {}
-    for col in df.columns:
-        # Intentar mapear las columnas usando los sinónimos globales
-        for clave, sin in sinonimos_global.items():
-            if col in sin:
-                mapeo[clave] = col
-                break
-        # Si no se encuentra, intentar con sinónimos del proveedor (si existen)
-        if clave not in mapeo and sinonimos_proveedor:
-            for clave, sin in sinonimos_proveedor.items():
-                if col in sin:
-                    mapeo[clave] = col
-                    break
-    return mapeo
 
 def validar_columnas_vacias(df):
     """Verifica que no haya valores vacíos en las columnas requeridas."""


### PR DESCRIPTION
## Summary
- delete duplicated `mapear_columnas` helper from `views.py`
- keep using the function from `normapy.mapeo.normalizador`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687f7e6534b88322a821d578c42b3d91