### PR TITLE
Update secret key from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ El sistema detecta automáticamente los nombres de columna gracias al archivo `s
 
 5. Accede a la aplicación en tu navegador en `http://127.0.0.1:8000/`
 
+6. En entornos de producción define la variable de entorno `DJANGO_SECRET_KEY`
+   para establecer la clave secreta de Django.
+
 ---
 
 ## Pruebas automatizadas

--- a/normapy_project/settings.py
+++ b/normapy_project/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -20,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-h24*lu5i&noys&0r&!6l%-ot!7_9o1ut(r!cn$qcd=22n$xypw'
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "clave-insegura")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
## Summary
- load Django `SECRET_KEY` from the environment
- mention `DJANGO_SECRET_KEY` in the install steps

## Testing
- `python manage.py test normapy.tests` *(fails: Could not import Django)*


------
https://chatgpt.com/codex/tasks/task_e_687f7e661364832285f32c25d891e236