### PR TITLE
Update historial template fields

### DIFF
--- a/normapy/templates/normapy/historial.html
+++ b/normapy/templates/normapy/historial.html
@@ -34,17 +34,12 @@
         <tbody>
             {% for imp in historial %}
             <tr>
-codex/create-productos_por_importacion-template
-                <td>{{ imp.archivo_nombre }}</td>
-                <td>{{ imp.fecha|date:"Y-m-d H:i" }}</td>
-                <td>{{ imp.total_productos }}</td>
+                <td>{{ imp.nombre_original }}</td>
+                <td>{{ imp.fecha_subida|date:"Y-m-d H:i" }}</td>
+                <td>{{ imp.cantidad_productos }}</td>
                 <td>
                     <a href="{% url 'productos_por_importacion' imp.id %}">Ver productos</a>
                 </td>
-
-                <td>{{ imp.nombre_original }}</td>
-                <td>{{ imp.fecha_subida|date:"Y-m-d H:i" }}</td>
-main
             </tr>
             {% empty %}
             <tr><td colspan="3">No hay importaciones registradas.</td></tr>


### PR DESCRIPTION
## Summary
- update historial importaciones template to use new field names
- clean redundant markup

## Testing
- `python manage.py test normapy.tests` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687f7e706b4883229f8b6925bec16761