### PR TITLE
Remove unused imports

### DIFF
--- a/normapy/mapeo/normalizador.py
+++ b/normapy/mapeo/normalizador.py
@@ -3,9 +3,6 @@ Módulo para la lógica de mapeo automático de columnas.
 """
 
 import pandas as pd
-import json
-import os
-import re
 from unidecode import unidecode
 from rapidfuzz import fuzz
 import logging


### PR DESCRIPTION
## Summary
- clean up `normapy/mapeo/normalizador.py` by dropping unused imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9787663c8322931bf35414163761