### PR TITLE
Fix stray markers in views and urls

### DIFF
--- a/normapy/urls.py
+++ b/normapy/urls.py
@@ -18,8 +18,5 @@ urlpatterns = [
 
 # Servir archivos media y estáticos en desarrollo
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-4max6j-codex/add-trailing-newline-to-urls.py
 urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
-urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT) 
-main

--- a/normapy/views.py
+++ b/normapy/views.py
@@ -10,11 +10,9 @@ import os
 from django.db.models import Count
 from django.http import HttpResponse
 from .utils.limpieza import limpieza_basica
-from .mapeo.normalizador import mapear_columnas  # Usar la versión extendida
-codex/remove-duplicate-limpiar_columnas-in-views.py
+from .mapeo.normalizador import mapear_columnas
 from .mapeo.validacion import limpiar_columnas
 from .utils.logger import logger
-main
 import json as pyjson
 from django.utils import timezone
 from django.http import FileResponse


### PR DESCRIPTION
## Summary
- clean up autogenerated markers in `views.py` and `urls.py`
- ensure imports use the right names
- remove duplicated static files handler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fab6db6d88322a75e8088e2fd1031