### PR TITLE
Fix urls.py stray text and clean views

### DIFF
--- a/normapy/urls.py
+++ b/normapy/urls.py
@@ -18,8 +18,4 @@ urlpatterns = [
 
 # Servir archivos media y estáticos en desarrollo
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-4max6j-codex/add-trailing-newline-to-urls.py
 urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
-
-urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT) 
-main

--- a/normapy/views.py
+++ b/normapy/views.py
@@ -11,10 +11,8 @@ from django.db.models import Count
 from django.http import HttpResponse
 from .utils.limpieza import limpieza_basica
 from .mapeo.normalizador import mapear_columnas  # Usar la versión extendida
-codex/remove-duplicate-limpiar_columnas-in-views.py
 from .mapeo.validacion import limpiar_columnas
 from .utils.logger import logger
-main
 import json as pyjson
 from django.utils import timezone
 from django.http import FileResponse


### PR DESCRIPTION
## Summary
- clean up stray merge artifacts in `normapy/urls.py`
- remove leftover markers in `normapy/views.py`

## Testing
- `python manage.py check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fab6d0b2483229fe57b59a1c9976c