### PR TITLE
Fix URL includes for named views

### DIFF
--- a/normapy/views.py
+++ b/normapy/views.py
@@ -371,10 +371,12 @@ class ProductoViewSet(ModelViewSet):
     queryset = Producto.objects.all()
     serializer_class = ProductoSerializer
 
-def importar(request):
+def importar_react(request):
+    """Placeholder view served by the React frontend."""
     from django.http import HttpResponse
     return HttpResponse("Página de Importar (servida por React)")
 
-def dashboard(request):
+def dashboard_react(request):
+    """Placeholder dashboard view served by the React frontend."""
     from django.http import HttpResponse
     return HttpResponse("Página de Dashboard (servida por React)")

--- a/normapy_project/urls.py
+++ b/normapy_project/urls.py
@@ -17,7 +17,11 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from normapy.views import ProductoViewSet, importar, dashboard, bienvenida
+from normapy.views import (
+    ProductoViewSet,
+    importar_react,
+    bienvenida,
+)
 
 router = DefaultRouter()
 router.register(r'productos', ProductoViewSet, basename='producto')
@@ -25,8 +29,8 @@ router.register(r'productos', ProductoViewSet, basename='producto')
 urlpatterns = [
     path('api/', include(router.urls)),
     path('api-auth/', include('rest_framework.urls')),
-    path('importar/', importar),
-    path('dashboard/', dashboard),
+    path('importar/', importar_react),
     path('admin/', admin.site.urls),
+    path('', include('normapy.urls')),
     path('', bienvenida, name='bienvenida'),
 ]


### PR DESCRIPTION
## Summary
- include `normapy.urls` at the project level
- adjust placeholder views to avoid clashing with real templates
- remove conflicting dashboard route
- make sure tests install xlrd/xlwt

## Testing
- `pip install pytest pytest-django xlwt xlrd`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fdd2cc83c8322b9b7a417dd7043bb