### PR TITLE
Add API base URL env config to frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ db.sqlite3
 
 # Environments
 .env
+!frontend/.env
 .venv
 env/
 venv/

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8000

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,19 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Configuración de variables de entorno
+
+Para indicar la URL de la API que consume el frontend se utiliza la variable
+`VITE_API_BASE_URL`. Debes crear un archivo `.env` dentro de la carpeta
+`frontend` con el siguiente contenido para desarrollo:
+
+```env
+VITE_API_BASE_URL=http://localhost:8000
+```
+
+En producción ajusta este valor apuntando al dominio donde se despliegue el
+backend.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -13,7 +13,7 @@ export default function Dashboard() {
   const [productos, setProductos] = useState<Producto[]>([]);
 
   useEffect(() => {
-    fetch("http://localhost:8000/api/productos/")
+    fetch(`${import.meta.env.VITE_API_BASE_URL}/api/productos/`)
       .then((res) => res.json())
       .then(setProductos)
       .catch((err) => console.error("Error:", err));


### PR DESCRIPTION
## Summary
- allow tracking frontend/.env in gitignore
- fetch products using VITE_API_BASE_URL in Dashboard
- document variable usage in frontend README
- include default .env file for development

## Testing
- `pytest -q` *(fails: ImproperlyConfigured settings)*

------
https://chatgpt.com/codex/tasks/task_e_687fdef387ec8322832cabac41e41af6