### PR TITLE
Update dashboard routes and remove simplified view

### DIFF
--- a/normapy/views.py
+++ b/normapy/views.py
@@ -375,8 +375,3 @@ def importar_react(request):
     """Placeholder view served by the React frontend."""
     from django.http import HttpResponse
     return HttpResponse("Página de Importar (servida por React)")
-
-def dashboard_react(request):
-    """Placeholder dashboard view served by the React frontend."""
-    from django.http import HttpResponse
-    return HttpResponse("Página de Dashboard (servida por React)")

--- a/normapy_project/urls.py
+++ b/normapy_project/urls.py
@@ -19,7 +19,8 @@ from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from normapy.views import (
     ProductoViewSet,
-    importar_react,
+    importar_archivo,
+    dashboard,
     bienvenida,
 )
 
@@ -29,7 +30,8 @@ router.register(r'productos', ProductoViewSet, basename='producto')
 urlpatterns = [
     path('api/', include(router.urls)),
     path('api-auth/', include('rest_framework.urls')),
-    path('importar/', importar_react),
+    path('importar/', importar_archivo),
+    path('dashboard/', dashboard, name='dashboard'),
     path('admin/', admin.site.urls),
     path('', include('normapy.urls')),
     path('', bienvenida, name='bienvenida'),


### PR DESCRIPTION
## Summary
- remove unused `dashboard_react` function
- route `dashboard/` to the full dashboard view
- use `importar_archivo` in root URL configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fdef29d208322aea244a4575d57c3