### PR TITLE
Remove unused imports from views

### DIFF
--- a/normapy/views.py
+++ b/normapy/views.py
@@ -7,11 +7,8 @@ from .forms import UploadForm
 from .models import Producto, Importacion
 import json
 import os
-from django.db.models import Count
 from django.http import HttpResponse
-from .utils.limpieza import limpieza_basica
 from .mapeo.normalizador import mapear_columnas  # Usar la versión extendida
-from .mapeo.normalizador import mapear_columnas
 from .mapeo.validacion import limpiar_columnas
 from .utils.logger import logger
 import json as pyjson
@@ -21,7 +18,6 @@ from unidecode import unidecode
 from datetime import datetime
 from django.db.models import Avg, Sum
 from rest_framework.viewsets import ModelViewSet
-from .models import Producto
 from .serializers import ProductoSerializer
 
 # Cargar sinonimos.json desde disco


### PR DESCRIPTION
## Summary
- remove duplicate `mapear_columnas` import
- drop unused imports including `limpieza_basica`
- verify there are no unused imports with `flake8`

## Testing
- `flake8 normapy/views.py | head -n 5`
- `pytest -q` *(fails: ImproperlyConfigured)*

------
https://chatgpt.com/codex/tasks/task_e_687fdef43380832287891860612bb68d